### PR TITLE
patch insert test demo

### DIFF
--- a/rest/data/patch_test.go
+++ b/rest/data/patch_test.go
@@ -2,73 +2,73 @@ package data
 
 import (
 	"testing"
-
-	"gopkg.in/mgo.v2/bson"
-
 	"time"
-
-	"fmt"
 
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/testutil"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
 type PatchConnectorSuite struct {
-	ctx  Connector
-	time time.Time
+	ctx   Connector
+	time  time.Time
+	setup func() error
 	suite.Suite
 }
 
 func TestPatchConnectorSuite(t *testing.T) {
 	s := new(PatchConnectorSuite)
-	s.ctx = &DBConnector{}
-	//s.time = time.Now()
-	s.time = time.Date(2009, time.November, 10, 23, 0, 0, 0, time.Local)
+	s.setup = func() error {
+		s.ctx = &DBConnector{}
+		s.time = time.Now()
 
-	testutil.ConfigureIntegrationTest(t, testConfig, "TestPatchConnectorSuite")
-	db.SetGlobalSessionProvider(db.SessionFactoryFromConfig(testConfig))
+		testutil.ConfigureIntegrationTest(t, testConfig, "TestPatchConnectorSuite")
+		db.SetGlobalSessionProvider(db.SessionFactoryFromConfig(testConfig))
 
-	patch1 := &patch.Patch{Id: "patch1", Project: "project1", CreateTime: s.time}
-	patch2 := &patch.Patch{Id: "patch2", Project: "project2", CreateTime: s.time.Add(time.Second * 2)}
-	patch3 := &patch.Patch{Id: "patch3", Project: "project1", CreateTime: s.time.Add(time.Second * 4)}
-	patch4 := &patch.Patch{Id: "patch4", Project: "project1", CreateTime: s.time.Add(time.Second * 6)}
-	patch5 := &patch.Patch{Id: "patch5", Project: "project2", CreateTime: s.time.Add(time.Second * 8)}
-	patch6 := &patch.Patch{Id: "patch6", Project: "project1", CreateTime: s.time.Add(time.Second * 10)}
+		patches := []*patch.Patch{
+			{Id: "patch1", Project: "project1", CreateTime: s.time},
+			{Description: "patch2", Project: "project2", CreateTime: s.time.Add(time.Minute * 2)},
+			{Description: "patch3", Project: "project1", CreateTime: s.time.Add(time.Minute * 4)},
+			{Description: "patch4", Project: "project1", CreateTime: s.time.Add(time.Minute * 6)},
+			{Description: "patch5", Project: "project2", CreateTime: s.time.Add(time.Minute * 8)},
+			{Description: "patch6", Project: "project1", CreateTime: s.time.Add(time.Minute * 10)},
+		}
 
-	assert.NoError(t, patch1.Insert())
-	assert.NoError(t, patch2.Insert())
-	assert.NoError(t, patch3.Insert())
-	assert.NoError(t, patch4.Insert())
-	assert.NoError(t, patch5.Insert())
-	assert.NoError(t, patch6.Insert())
+		for _, p := range patches {
+			if err := p.Insert(); err != nil {
+				return err
+			}
+		}
 
-	//bson.M{}
-	p, _ := patch.Find(db.Query(bson.M{"create_time": bson.M{"$lte": s.time}}))
-	//p, _ := patch.Find(db.Query(bson.M{"create_time": s.time}))
+		return nil
+	}
 
-	fmt.Println(p)
-	fmt.Println(s.time)
 	suite.Run(t, s)
 }
 
 func TestMockPatchConnectorSuite(t *testing.T) {
 	s := new(PatchConnectorSuite)
-	s.time = time.Now().UTC()
-	s.ctx = &MockConnector{MockPatchConnector: MockPatchConnector{
-		CachedPatches: []patch.Patch{
-			{Id: "patch1", Project: "project1", CreateTime: s.time},
-			{Id: "patch2", Project: "project2", CreateTime: s.time.Add(time.Second * 2)},
-			{Id: "patch3", Project: "project1", CreateTime: s.time.Add(time.Second * 4)},
-			{Id: "patch4", Project: "project1", CreateTime: s.time.Add(time.Second * 6)},
-			{Id: "patch5", Project: "project2", CreateTime: s.time.Add(time.Second * 8)},
-			{Id: "patch6", Project: "project1", CreateTime: s.time.Add(time.Second * 10)},
-		},
-	}}
+	s.setup = func() error {
+		s.time = time.Now().UTC()
+		s.ctx = &MockConnector{MockPatchConnector: MockPatchConnector{
+			CachedPatches: []patch.Patch{
+				{Id: "patch1", Project: "project1", CreateTime: s.time},
+				{Id: "patch2", Project: "project2", CreateTime: s.time.Add(time.Second * 2)},
+				{Id: "patch3", Project: "project1", CreateTime: s.time.Add(time.Second * 4)},
+				{Id: "patch4", Project: "project1", CreateTime: s.time.Add(time.Second * 6)},
+				{Id: "patch5", Project: "project2", CreateTime: s.time.Add(time.Second * 8)},
+				{Id: "patch6", Project: "project1", CreateTime: s.time.Add(time.Second * 10)},
+			},
+		}}
+
+		return nil
+	}
+
 	suite.Run(t, s)
 }
+
+func (s *PatchConnectorSuite) SetupSuite() { s.Require().NoError(s.setup()) }
 
 func (s *PatchConnectorSuite) TestFetchTooManyAsc() {
 	patches, err := s.ctx.FindPatchesByProject("project2", s.time, 3, 1)


### PR DESCRIPTION
I think there were two problems which compounded each other.

1. First, I think the asserts we were doing in the test setup function weren't working. I don't know why that's the case, and I haven't dug further into that. We might be able to figure things out a bit more clearly if we dug into it more. I don't know if it's worth the time, now, but if you want to figure out how that worked, it's worth while. This bug hid the #2 bug. I've fixed it by making the setup function a property of the struct, and then used the suite's SetupSuite functionality to actually do the required setup. 
2. The Id field in the test fixture, is set to a ObjectId type, which is an alias for a string (therefore your mock'ed values worked. The reason why the mgo driver implements objectids as strings is probably a bit quirky (I think I'd do them as byte arrays. However, when we serialize the struct to bson, we ensure that the object ids are the proper length. Which means, you're getting a type error as a runtime error. Which is fun.

I've left a case of 2 in this patch, so you can see the error.

The tests in this suite don't pass, but I think that's because the timestamps in go store a slightly higher precision than the ones that round trip through MongoDB. I think you can probably fix this by rounding all times to second, or avoiding doing Equality comparisons. We can talk more about this too.